### PR TITLE
Fix make setup buf

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -46,7 +46,7 @@ jobs:
         chown -R testbot:testbot .
         sudo -u testbot bash -lc 'cd viam-cartographer && make clean'
         
-    - name: make bufinstall buf setup
+    - name: make setup buf
       uses: nick-fields/retry@v2
       with:
         timeout_minutes: 5
@@ -55,7 +55,7 @@ jobs:
         shell: bash
         command: |
           chown -R testbot:testbot .
-          sudo -u testbot bash -lc 'cd viam-cartographer && make bufinstall buf setup'
+          sudo -u testbot bash -lc 'cd viam-cartographer && make setup buf'
 
     - name: make build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
             exit 1
         fi
 
-    - name: make bufinstall buf setup
+    - name: make setup buf
       uses: nick-fields/retry@v2
       with:
         timeout_minutes: 5
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         command: |
           chown -R testbot:testbot .
-          sudo -u testbot bash -lc 'make bufinstall buf setup'
+          sudo -u testbot bash -lc 'make setup buf'
 
     - name: make build
       run: |

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@ TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):${PATH}"
 PKG_PATH=${PKG_CONFIG_PATH}:`brew --prefix`/opt/openssl@3/lib/pkgconfig
 
-bufinstall:
-	sudo apt-get install -y protobuf-compiler-grpc libgrpc-dev libgrpc++-dev || brew install grpc openssl --quiet
-
 bufsetup:
 	GOBIN=`pwd`/grpc/bin go install github.com/bufbuild/buf/cmd/buf@v1.8.0
 	ln -sf `which grpc_cpp_plugin` grpc/bin/protoc-gen-grpc-cpp

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ These containers are set to persist between sessions via the `persistent` parame
 #### Setup, build, and run the binary
 
 ```bash
-# Setup the gRPC files
-make bufinstall && make buf 
 # Install dependencies
 make setup
+# Setup the gRPC files
+make buf 
 # Build & install the binary
 make build
 make install

--- a/viam-cartographer/scripts/setup_cartographer_linux.sh
+++ b/viam-cartographer/scripts/setup_cartographer_linux.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Installing cartographer external dependencies"
 sudo apt update
-sudo apt install -y cmake ninja-build libgmock-dev libboost-iostreams-dev liblua5.3-dev libcairo2-dev python3-sphinx libabsl-dev libceres-dev libprotobuf-dev protobuf-compiler libpcl-dev
+sudo apt install -y cmake ninja-build libgmock-dev libboost-iostreams-dev liblua5.3-dev libcairo2-dev python3-sphinx libabsl-dev libceres-dev libprotobuf-dev protobuf-compiler libpcl-dev protobuf-compiler-grpc libgrpc-dev libgrpc++-dev

--- a/viam-cartographer/scripts/setup_cartographer_macos.sh
+++ b/viam-cartographer/scripts/setup_cartographer_macos.sh
@@ -2,7 +2,7 @@
 echo "Installing cartographer external dependencies"
 brew update
 brew upgrade
-brew install abseil boost ceres-solver protobuf ninja cairo googletest lua@5.3 pkg-config cmake 
+brew install abseil boost ceres-solver protobuf ninja cairo googletest lua@5.3 pkg-config cmake go@1.20 grpc
 brew link lua@5.3
 brew install openssl eigen gflags glog suite-sparse sphinx-doc pcl
 brew link protobuf


### PR DESCRIPTION
I encountered issues when testing changes made in https://github.com/viamrobotics/viam-cartographer/pull/69

The issues were that following the instructions on the README led to errors that had to be debugged manually.

The changes made in this PR fix these issues, and the user can run: `make setup`, `make buf`, and `make build` one after another.

Tested on Mac x86_64.